### PR TITLE
fix: Update aws_iam_role_policy_attachment and make codebuild role ou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,11 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_codebuild_project"></a> [codebuild\_project](#output\_codebuild\_project) | Name and ARN of codebuild project, to be used when running GitHub Actions |
-| <a name="output_codebuild_role"></a> [codebuild\_role](#output\_codebuild\_role) | Name and ARN of codebuild role, to be used when running GitHub Actions |
-| <a name="output_ecr_repository"></a> [ecr\_repository](#output\_ecr\_repository) | Name and ARN of ECR repository, to be used when to push custom docker images for the codebuiild project |
+| <a name="output_aws_security_group_id"></a> [aws\_security\_group\_id](#output\_aws\_security\_group\_id) | ID of the security group created for the codebuild project |
+| <a name="output_codebuild_project_arn"></a> [codebuild\_project\_arn](#output\_codebuild\_project\_arn) | ARN of the codebuild project, to be used when running GitHub Actions |
+| <a name="output_codebuild_project_name"></a> [codebuild\_project\_name](#output\_codebuild\_project\_name) | Name of the codebuild project, to be used when running GitHub Actions |
+| <a name="output_codebuild_role_name"></a> [codebuild\_role\_name](#output\_codebuild\_role\_name) | Name of the codebuild role, to be used when running GitHub Actions |
+| <a name="output_ecr_repository_name"></a> [ecr\_repository\_name](#output\_ecr\_repository\_name) | Name of the ECR repository, to be used when to push custom docker images for the codebuiild project |
 
 ----
 ### Providers

--- a/iam.tf
+++ b/iam.tf
@@ -148,11 +148,8 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional" {
-  for_each = {
-    for k, v in var.iam_role_policies :
-    k => v if local.create_iam_role
-  }
+  for_each = var.iam_role_policies
 
-  role       = aws_iam_role.this[0].name
+  role       = local.create_iam_role ? aws_iam_role.this[0].name : var.iam_role_name
   policy_arn = each.value
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,8 +8,8 @@ output "codebuild_project" {
 
 output "codebuild_role" {
   value = {
-    name = aws_iam_role.this[0].name
-    arn  = aws_iam_role.this[0].arn
+    name = try(aws_iam_role.this[0].name, null)
+    arn  = try(aws_iam_role.this[0].arn, null)
   }
   description = "Name and ARN of codebuild role, to be used when running GitHub Actions"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,23 +1,24 @@
-output "codebuild_project" {
-  value = {
-    name = aws_codebuild_project.this.name
-    arn  = aws_codebuild_project.this.arn
-  }
-  description = "Name and ARN of codebuild project, to be used when running GitHub Actions"
+output "codebuild_project_name" {
+  value       = aws_codebuild_project.this.name
+  description = "Name of the codebuild project, to be used when running GitHub Actions"
 }
 
-output "codebuild_role" {
-  value = {
-    name = try(aws_iam_role.this[0].name, null)
-    arn  = try(aws_iam_role.this[0].arn, null)
-  }
-  description = "Name and ARN of codebuild role, to be used when running GitHub Actions"
+output "codebuild_project_arn" {
+  value       = aws_codebuild_project.this.arn
+  description = "ARN of the codebuild project, to be used when running GitHub Actions"
 }
 
-output "ecr_repository" {
-  value = {
-    name = try(aws_ecr_repository.this[0].name, null)
-    arn  = try(aws_ecr_repository.this[0].arn, null)
-  }
-  description = "Name and ARN of ECR repository, to be used when to push custom docker images for the codebuiild project"
+output "codebuild_role_name" {
+  value       = try(aws_iam_role.this[0].name, var.iam_role_name)
+  description = "Name of the codebuild role, to be used when running GitHub Actions"
+}
+
+output "ecr_repository_name" {
+  value       = try(aws_ecr_repository.this[0].name, null)
+  description = "Name of the ECR repository, to be used when to push custom docker images for the codebuiild project"
+}
+
+output "aws_security_group_id" {
+  value       = try(aws_security_group.codebuild[0].id, null)
+  description = "ID of the security group created for the codebuild project"
 }


### PR DESCRIPTION
Update "aws_iam_role_policy_attachment" and make codebuild role output optional

- Update "aws_iam_role_policy_attachment" to attach additional policies to input role if added
- Update codebuild role output to be optional. This is to cater for when the module does not need to create a role when an input role is used